### PR TITLE
Follow redirect curl

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -84,7 +84,11 @@ fi
 args_url="$endpoint$repository/$file"
 
 # echo -f $args_security "-O" "$args_url"
-MSG=`curl -f $args_security "-O" "$args_url"`
+MSG=`curl -L -f $args_security "-O" "$args_url"`
+
+if [ -z $MSG ]; then
+  MSG="{}"
+fi
 
 if echo $MSG | jq -e 'has("errors")' >/dev/null ; then
   echo "Endpoint returned server error:"


### PR DESCRIPTION
We had an issue with Artifactory downloading 0B images.

Adding ` -L, --location      Follow redirects` in the curl command so that the downloaded artifact won't be empty.

See the fix [here](https://concourse.int.adgear.com/teams/trader/pipelines/adgear-trader-build/jobs/build-trader-base-image/builds/37)